### PR TITLE
Use kramdown (fixes #48)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,7 @@ youtube_url: https://www.youtube.com/channel/UCZN40A4qBYyMHvFwmRmeUkw
 # Build settings
 
 permalink: /blog/:year/:month/:day/:title/
-markdown: redcarpet
-redcarpet:
-  extensions: ["smart", "tables", "no_intra_emphasis", "fenced_code_blocks", "autolink", "strikethrough", "superscript", "with_toc_data"]
+markdown: kramdown
 exclude:
   - CNAME
   - LICENSE


### PR DESCRIPTION
The site looks fine, and the setting was `kramdown` before anyway.

The only thing I’m not sure about is whether code highlighting still works (we used pygments before), but since there is no code highlighting used on the site, it’s fine for now. 