### PR TITLE
Added orientation page

### DIFF
--- a/welcome/index.html
+++ b/welcome/index.html
@@ -1,0 +1,20 @@
+---
+layout: page-with-title
+title: Welcome To TechSoc!
+permalink: /welcome/
+redirect_from: /welcome.html
+navigation: false
+---
+<!-- order: 2 -->
+
+
+<div class="row">
+  <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">
+    <div class="about-content post-content">
+      <h2 class="page-heading">Thanks for joining TechSoc</h2>
+        <p>Thank you for deciding to become a TechSoc member. As a part of your membership, you're welcome to attend any <a href="/events">event</a> we hold, from tech talks to office tours. Your support actively helps fund this society.</p>
+        <p>So, what's next? Firstly, you'll probably want to follow us on social media for the latest updates and photos (links at the bottom of this page). Contact us if you'd like to be on the mailing list if you're not already, so you can get information on the latest events right in your inbox.</p>
+        <p>Finally, please do join our <a href="//techsochq.slack.com">Slack channel</a>, where you'll be able to chat with other TechSoc members. It's pretty fantastic!</p>
+    </div>
+  </div>
+</div>

--- a/welcome/index.html
+++ b/welcome/index.html
@@ -12,7 +12,7 @@ navigation: false
   <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">
     <div class="about-content post-content">
       <h2 class="page-heading">Thanks for joining TechSoc</h2>
-        <p>Thank you for deciding to become a TechSoc member. As a part of your membership, you're welcome to attend any <a href="/events">event</a> we hold, from tech talks to office tours. Your support actively helps fund this society.</p>
+        <p>Thank you for deciding to become a TechSoc member. As a part of your membership, you're welcome to attend any <a href="{{ site.baseurl }}/events">event</a> we hold, from tech talks to office tours. Your support actively helps fund this society.</p>
         <p>So, what's next? Firstly, you'll probably want to follow us on social media for the latest updates and photos (links at the bottom of this page). Contact us if you'd like to be on the mailing list if you're not already, so you can get information on the latest events right in your inbox.</p>
         <p>Finally, please do join our <a href="//techsochq.slack.com">Slack channel</a>, where you'll be able to chat with other TechSoc members. It's pretty fantastic!</p>
     </div>


### PR DESCRIPTION
As an answer to issue #56, I created this simple page for new members to orient themselves with the many communication channels we now have.

It would be found at the /welcome endpoint. Also, I didn't add a newsletter subscription as I'm not sure how we'll do these yet with the new Ublend system (probably a Google Spreadsheet? Obviously data protection is important etc.)

Let me know what you all think, perhaps there should be an image at the bottom, or a video?