### PR TITLE
Improve facebook script

### DIFF
--- a/_events/ask-the-interns-2016.md
+++ b/_events/ask-the-interns-2016.md
@@ -3,7 +3,7 @@ facebook_id: '1606401832990059'
 title: Ask the Interns
 start_time: '2016-10-20 19:00'
 end_time: '2016-10-20 20:30'
-location: TBC
+location: 'Elvin Hall, Institute of Education, 20 Bedford Way, London WC1H 0AL'
 ---
 
 Internship hunting is upon us! We are bringing in a panel of past interns who have worked at different technology companies to share their experience of the application process as well as the company culture.  

--- a/_events/coding-and-cookies/coding-and-cookies-what-makes-a-website-intro-to-front-end.md
+++ b/_events/coding-and-cookies/coding-and-cookies-what-makes-a-website-intro-to-front-end.md
@@ -1,7 +1,7 @@
 ---
 facebook_id: '1793239157620054'
 title: 'Coding & Cookies: What makes a website? [Intro to Front-End]'
-location: TBC
+location: Chadwick G07
 series_id: coding-and-cookies
 start_time: '2016-10-14 18:00'
 end_time: '2016-10-14 20:30'

--- a/_events/hackathons/porticode.md
+++ b/_events/hackathons/porticode.md
@@ -2,8 +2,8 @@
 facebook_id: '1615486518782160'
 title: Porticode
 series_id: hackathons
-start_time: '2016-12-10 09:00'
-end_time: '2016-12-11 17:00'
+start_time: '2016-12-10 08:00'
+end_time: '2016-12-11 11:00'
 location: University College London
 actions:
   - label: Tickets

--- a/_events/socials/techsoc-presents-phineas-and-loop.md
+++ b/_events/socials/techsoc-presents-phineas-and-loop.md
@@ -4,7 +4,7 @@ title: 'TechSoc presents: Phineas and Loop'
 series_id: socials
 start_time: '2016-06-08 19:30'
 end_time: '2016-06-09 04:20'
-location: Phineas Bar UCL
+location: Phineas Bar Ucl
 ---
 
 It is finally the end of the year so join us for the last sportsnight this wednesday and celebrate the end of exams/coursework/!change the world!  

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/techsoc/website-2015#readme",
   "devDependencies": {
     "browser-sync": "^2.9.11",
+    "chalk": "^1.1.3",
     "front-matter": "^2.0.0",
     "glob": "^6.0.1",
     "gulp": "^3.9.0",


### PR DESCRIPTION
The `facebook-sync` script now auto-updates start, end and location from Facebook data, rather than just printing diffs to the console.