### PR TITLE
Auto categorise imported events

### DIFF
--- a/_events/open-hours/join-the-techsoc-volunteering-crew.md
+++ b/_events/open-hours/join-the-techsoc-volunteering-crew.md
@@ -4,7 +4,7 @@ title: Join the TechSoc Volunteering Crew
 start_time: '2016-10-31 16:30'
 end_time: '2016-10-31 18:30'
 location: 'UCLU CSC Conference Room, 2nd Floor, Bloomsbury Theatre Building'
-series_id: open-hour
+series_id: open-hours
 ---
 
 At TechSoc, we believe that technology can be put to good use improving the lives of people all around the world.  

--- a/_events/open-hours/techsoc-open-hour-2.md
+++ b/_events/open-hours/techsoc-open-hour-2.md
@@ -3,7 +3,7 @@ facebook_id: '243998899352833'
 title: TechSoc Open Hour
 start_time: '2016-11-24 17:00'
 end_time: '2016-11-24 18:00'
-series_id: open-hour
+series_id: open-hours
 ---
 
 Join us for another evening of chilling with the mentors and TechSoc committee. We will have a few activities lined up...FREE PIZZA as well!  

--- a/_events/open-hours/techsoc-open-hour.md
+++ b/_events/open-hours/techsoc-open-hour.md
@@ -4,7 +4,7 @@ title: TechSoc Open Hour
 start_time: '2016-10-27 19:00'
 end_time: '2016-10-27 21:00'
 location: South Wing 9 Garwood LT
-series_id: open-hour
+series_id: open-hours
 ---
 
 Join us for an evening of chilling with the mentors and TechSoc committee. We will have a few activities lined up...free pizza as well!  

--- a/_series/open-hours.mdown
+++ b/_series/open-hours.mdown
@@ -1,5 +1,5 @@
 ---
-series_id: open-hour
+series_id: open-hours
 title: Open Hour
 start_time: "2016-10-15"
 end_time: "2017-10-15"

--- a/facebook-sync/categorise.js
+++ b/facebook-sync/categorise.js
@@ -1,0 +1,57 @@
+var _ = require("lodash");
+
+var categories = [
+  {
+    match: /coding.+cookies/i,
+    assign: { series_id: "coding-and-cookies" }
+  },
+  {
+    match: /cs50/i,
+    assign: { series_id: "cs50" }
+  },
+  {
+    match: /(virtual reality|vr).+project/i,
+    assign: { project_id: "vr-project" }
+  },
+  {
+    match: /hardware project/i,
+    assign: { project_id: "hardware-project" }
+  },
+  {
+    match: /open hour/i,
+    assign: { series_id: "open-hours" }
+  },
+  {
+    match: /mixer|social/i,
+    assign: { series_id: "socials" }
+  },
+  {
+    match: /tech talk/i,
+    assign: { series_id: "tech-talks" }
+  }
+];
+
+function matches(match, d) {
+  if (_.isRegExp(match)) {
+    // for a regex, we only match against title
+    return match.test(d.attributes.title);
+  } else if (_.isFunction(match)) {
+    // for a function, pass whole event object
+    return match(d);
+  }
+  return false;
+}
+
+module.exports = function(event) {
+
+  for (var i = 0; i < categories.length; i++) {
+    var { match, assign } = categories[i];
+    if (matches(match, event)) {
+      _.assign(event.attributes, assign);
+      // if a match is found, we don't want to test for other matches
+      break;
+    }
+  }
+
+  return event;
+}

--- a/facebook-sync/index.js
+++ b/facebook-sync/index.js
@@ -114,9 +114,16 @@ function saveEventFile(event) {
   if (event.filename) {
     filename = event.filename;
   } else if (category) {
-    filename = path.join(
+    var dir = path.join(
       "_events",
-      category,
+      category
+    )
+    if (!fs.existsSync(dir)) {
+      // create directory if it doesn't exist
+      fs.mkdirSync(dir);
+    }
+    filename = path.join(
+      dir,
       slug(title, {lower: true}) + ".md"
     );
   } else {


### PR DESCRIPTION
I added some stupid guessing to the Facebook import script so that it auto-categorises events based on the title of the event. Check it and let me know if everything works/breaks.

Note that it’s **stupid**, so **you still need to review** the auto-categorised stuff, and **it doesn’t categorise everything**. This means you still need to rename those damn “import-“ files. Sorry about that.